### PR TITLE
Makefile: add OPENOCD_CMD variable for improved support of other open…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 
+#Put your personal build config in config.mk and DO NOT COMMIT IT!
+-include config.mk
+
 CROSS_COMPILE=arm-none-eabi-
 
 CC=$(CROSS_COMPILE)gcc
@@ -10,7 +13,7 @@ OPENOCD           ?= openocd
 OPENOCD_DIR       ?= 
 OPENOCD_INTERFACE ?= $(OPENOCD_DIR)interface/stlink-v2.cfg
 OPENOCD_TARGET    ?= target/nrf51_stlink.tcl
-
+OPENOCD_CMDS      ?=
 O                 ?= -O3
 
 INCLUDES= -I include/nrf -I s110/s110_nrf51822_7.0.0_API/include -I include/cm0 -I include/
@@ -50,15 +53,15 @@ clean:
 
 
 flash: $(PROGRAM).hex
-	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) -f $(OPENOCD_TARGET) -c init -c targets -c "reset halt" \
+	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) $(OPENOCD_CMDS) -f $(OPENOCD_TARGET) -c init -c targets -c "reset halt" \
                  -c "flash write_image erase $(PROGRAM).hex" -c "verify_image $(PROGRAM).hex" -c "reset halt" \
 	               -c "mww 0x4001e504 0x01" -c "mww 0x10001014 0x3F000" -c "reset run" -c shutdown
 
 reset:
-	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) -f $(OPENOCD_TARGET) -c init -c targets -c "mww 0x40000544 0x01" -c reset -c shutdown
+	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) $(OPENOCD_CMDS) -f $(OPENOCD_TARGET) -c init -c targets -c "mww 0x40000544 0x01" -c reset -c shutdown
 
 openocd: $(PROGRAM).elf
-	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) -f $(OPENOCD_TARGET) -c init -c targets
+	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) $(OPENOCD_CMDS) -f $(OPENOCD_TARGET) -c init -c targets
 
 gdb: $(PROGRAM).elf
 	$(GDB) -ex "target remote localhost:3333" -ex "monitor reset halt" $^


### PR DESCRIPTION
…ocd interfaces (such as J-Link).
